### PR TITLE
Add specs

### DIFF
--- a/hash_path.gemspec
+++ b/hash_path.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |gem|
   gem.name          = "hash_path"
   gem.require_paths = ["lib"]
   gem.version       = HashPath::VERSION
+  gem.add_development_dependency 'rspec', '~> 3.1'
+  gem.add_development_dependency 'pry'
 end

--- a/lib/hash_path.rb
+++ b/lib/hash_path.rb
@@ -15,7 +15,7 @@ module HashPath
   # Same as at_path but raises when a path is not found
   # The raise will give a delimited path of where the path went dead
   # @example
-  #   f = { 'foo' => {'bar' => {'baz' => 'hai'}, "baz" => [1,2] } }
+  #   f = { 'foo' => {'bar' => {'baz' => 'hai'} }, "baz" => [1,2] }
   #   f.at_path!('foo.not.baz') # Raises, message == 'foo.not'
   #   f.at_path!('not.here.yo') # Raises, message == 'not'
   #   f.at_path!('foo.bar.not') # Raises, message == 'foo.bar.not'

--- a/spec/hash_path_spec.rb
+++ b/spec/hash_path_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+RSpec.describe HashPath do
+  describe '#at_path' do
+    it 'returns nil if the key is not found' do
+      expect({}.at_path('foo')).to eq(nil)
+    end
+
+    it 'returns a value if it is found' do
+      expect({foo: {bar: 5}}.at_path('foo.bar')).to eq(5)
+    end
+  end
+
+  describe '#at_path!' do
+    it 'looks up a key given by a string' do
+      expect({'foo' => 5}.at_path!('foo')).to eq(5)
+    end
+
+    it 'finds a symbol when searching by a string' do
+      expect({foo: 5}.at_path!('foo')).to eq(5)
+    end
+
+    it 'looks up a key given by a symbol' do
+      expect({foo: 5}.at_path!(:foo)).to eq(5)
+    end
+
+    it 'looks up a symbol key given by an array' do
+      expect({foo: 5}.at_path!(['foo'])).to eq(5)
+    end
+
+    it 'looks up a string key given by an array' do
+      expect({'foo' => 5}.at_path!(['foo'])).to eq(5)
+    end
+
+    it 'looks up an object key' do
+      expect({73 => 5}.at_path!([73])).to eq(5)
+    end
+
+    it 'looks up a second level value' do
+      expect({foo: {bar: 5}}.at_path!(['foo', :bar])).to eq(5)
+    end
+
+    it 'raises a nice error when top-level key not found' do
+      expect {
+        {}.at_path!(['foo', 'bar'])
+      }.to raise_error(HashPath::PathNotFound, 'foo')
+    end
+
+    it 'raises a nice error when second-level key not found' do
+      expect {
+        {foo: {}}.at_path!(['foo', 'bar'])
+      }.to raise_error(HashPath::PathNotFound, 'foo.bar')
+    end
+
+    context 'a few more cases' do
+      let(:hash) { { 'foo' => {'bar' => {'baz' => 'hai'} }, "baz" => [11,22] } }
+
+      it 'throws an exception with middle key missing' do
+        expect { hash.at_path!('foo.not.baz') }.to raise_error(HashPath::PathNotFound, 'foo.not')
+      end
+
+      it 'throws an exception with first key missing' do
+        expect { hash.at_path!('not.here.yo') }.to raise_error(HashPath::PathNotFound, 'not')
+      end
+
+      it 'throws an exception with third key missing' do
+        expect { hash.at_path!('foo.bar.not') }.to raise_error(HashPath::PathNotFound, 'foo.bar.not')
+      end
+
+      it 'can traverse an array with a zero-based integer' do
+        expect(hash.at_path!('baz.1')).to eq(22)
+      end
+    end
+  end
+
+  describe '#flatten_key_paths' do
+    it 'un-nests hashes' do
+      expect({a: 5, b: {c: 7}}.flatten_key_paths).to eq({'a' => 5, 'b.c' => 7})
+    end
+  end
+
+  describe 'HashPath::VERSION' do
+    it 'is set' do
+      expect(HashPath::VERSION).not_to eq(nil)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure(&:disable_monkey_patching!)
+
+require 'hash_path'


### PR DESCRIPTION
The process of turning the comments into specs actually found a bug in the example given.

Should be straightforward. These specs were written by commenting out the whole file and re-enabling as I went, test-driving it.

cc @ggilder @tamird 
