### PR TITLE
Version 0 4 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change log
+
+## 0.4.0
+### 2014-11-25
+
+- Now at_path and at_path! can look up keys which are symbols, rather than strings.
+
+## 0.3.0
+### 2012-10-09
+
+- Start of the change log. Adds at_path, at_path!, and flatten_key_paths methods to Hash.

--- a/lib/hash_path/version.rb
+++ b/lib/hash_path/version.rb
@@ -1,3 +1,3 @@
 module HashPath
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
If you merge #3 first you'll just see a new version number and change log for this pull request.

This also is a request to publish to rubygems after merging. The version now on rubygems does not handle `{foo: 3}.at_path('foo')` correctly (where by "correctly" I mean "return 3").
