### PR TITLE
Set homepage in gemspec.

### DIFF
--- a/hash_path.gemspec
+++ b/hash_path.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["dneighman@squareup.com"]
   gem.description   = %q{Easy path navigation for hashes}
   gem.summary       = %q{Easy path navigation for hashes. Useful in specs}
-  gem.homepage      = ""
+  gem.homepage      = 'https://github.com/hassox/hash_path'
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
The purpose is so that we'll see a `Homepage` link at https://rubygems.org/gems/hash_path like the one at, for example, https://rubygems.org/gems/jruby-openssl
